### PR TITLE
Use ISO 8601 date as logfile name

### DIFF
--- a/rir/src/utils/ContextualProfiling.cpp
+++ b/rir/src/utils/ContextualProfiling.cpp
@@ -28,10 +28,13 @@ namespace rir {
 			ofstream myfile;
 
 			FileLogger() {
-				auto timenow = chrono::system_clock::to_time_t(chrono::system_clock::now());
-				string runId = (string)ctime(&timenow);
+				// use ISO 8601 date as log name
+				time_t timenow = chrono::system_clock::to_time_t(chrono::system_clock::now());
+				stringstream runId_ss;
+				runId_ss << put_time( localtime( &timenow ), "%FT%T%z" );
+				string runId = runId_ss.str();
 
-				myfile.open("profile/"+runId+".csv");
+				myfile.open("profile/" + runId + ".csv");
 				myfile << "Sno,id,name,type,callCount,callContexts,PIRCompiled\n";
 
 			}


### PR DESCRIPTION
Currently, the log file name contains a newline which can be a bit annoying to work with (breaks line completion in my shell for instance). This commit makes the date follow the ISO 8601 convention (eg `2021-05-25T14:09:59+00:00`), which I find a bit easier to work with.