### PR TITLE
Handle namespaced functions in logger + better handling of anonymous functions

### DIFF
--- a/rir/src/utils/ContextualProfiling.cpp
+++ b/rir/src/utils/ContextualProfiling.cpp
@@ -14,13 +14,46 @@ namespace rir {
 
 	namespace {
 		using namespace std;
-		// bool error = false;
-		// string errorMessage = "";
+
+		// Some functions are named, some are anonymous:
+		// FunLabel is a base class used to get the name of the function
+		// in both cases
+		class FunLabel {
+			public:
+				virtual ~FunLabel() = default;
+				virtual string get_name() = 0;
+				virtual bool is_anon() = 0;
+		};
+
+		class FunLabel_anon : public FunLabel {
+		private:
+			int const id = 0;
+		public:
+			FunLabel_anon(int id) : id{id} {};
+			string get_name() override {
+				stringstream ss;
+				ss << "*ANON_FUN_" << id << "*";
+				return ss.str();
+			}
+			bool is_anon() override { return true; }
+		};
+
+		class FunLabel_named : public FunLabel {
+		private:
+			string const name;
+		public:
+			FunLabel_named(string name) : name{move(name)} {};
+			string get_name() override {
+				return name;
+			}
+			bool is_anon() override { return false; }
+		};
 
 		unordered_map<size_t, set<string>> callContexts; // callContexts
 		unordered_map<size_t, int> callCount; // callCount
 		unordered_map<string, int> contextCallCount; // callCount
-		unordered_map<size_t, string> basicData; // function name, type
+		unordered_map<size_t, string> basicData; // function id, type
+		unordered_map<size_t, unique_ptr<FunLabel>> names; // names: either a string, or an id for anonymous functions
 		set<size_t> entries; // id's of all the methods
 		string del = ",";
 
@@ -33,28 +66,33 @@ namespace rir {
 
 				myfile.open("profile/"+runId+".csv");
 				myfile << "Sno,id,name,type,callCount,callContexts,PIRCompiled\n";
-
 			}
 
 			string getFunctionName(CallContext& call) {
 				static const SEXP double_colons = Rf_install("::");
 				static const SEXP triple_colons = Rf_install(":::");
-				SEXP lhs = CAR(call.ast);
 
-				string name;
+				size_t const currentKey = (size_t) call.callee;
+				SEXP const lhs = CAR(call.ast);
 
-				if (TYPEOF(lhs) == SYMSXP)
-					name = CHAR(PRINTNAME(lhs));
-				else if (TYPEOF(lhs) == LANGSXP && ((CAR(lhs) == double_colons) || (CAR(lhs) == triple_colons))) {
-					SEXP fun1 = CAR(lhs);
-					SEXP pkg = CADR(lhs);
-					SEXP fun2 = CADDR(lhs);
-					assert(TYPEOF(pkg) == SYMSXP && TYPEOF(fun2) == SYMSXP);
-					string fun1_name = CHAR(PRINTNAME(fun1));
-					string pkg_name = CHAR(PRINTNAME(pkg));
-					string fun2_name = CHAR(PRINTNAME(fun2));
-					name = pkg_name + fun1_name + fun2_name;
-				} else {
+				if (names.count(currentKey) == 0 || names[currentKey]->is_anon() ) {
+					if (TYPEOF(lhs) == SYMSXP) {
+						// case 1: function call of the form f(x,y,z)
+						names[currentKey] = make_unique<FunLabel_named>(CHAR(PRINTNAME(lhs)));
+					} else if (TYPEOF(lhs) == LANGSXP && ((CAR(lhs) == double_colons) || (CAR(lhs) == triple_colons))) {
+						// case 2: function call of the form pkg::f(x,y,z) or pkg:::f(x,y,z)
+						SEXP const fun1 = CAR(lhs);
+						SEXP const pkg = CADR(lhs);
+						SEXP const fun2 = CADDR(lhs);
+						assert(TYPEOF(pkg) == SYMSXP && TYPEOF(fun2) == SYMSXP);
+						stringstream ss;
+						ss << CHAR(PRINTNAME(pkg)) << CHAR(PRINTNAME(fun1)) << CHAR(PRINTNAME(fun2));
+						names[currentKey] = make_unique<FunLabel_named>(ss.str());
+					}
+				}
+				if (names.count(currentKey) == 0) {
+					// case 3: function call of the form F()(x, y, z)
+					// and this anonymous function has not been seen before
 					/*
 						TODO: Find a way to recover the name of named functions passed anonymously.
 						This mechanism would also handle `::` and `:::`. MWE:
@@ -63,12 +101,10 @@ namespace rir {
 							for (i in 1:10) { F()(1) }
 					*/
 					static int anon_fun_counter = 0;
-					stringstream ss;
-					ss << "`ANONYMOUS_FUNCTION_" << anon_fun_counter << "`";
+					names[currentKey] = make_unique<FunLabel_anon>(anon_fun_counter);
 					anon_fun_counter++;
-					name = ss.str();
 				}
-				return name;
+				return names[currentKey]->get_name();
 			}
 
 			string getFunType(int type) {
@@ -121,7 +157,6 @@ namespace rir {
 					// create basic data entry
 					basicData[currentKey] =
 						to_string(currentKey) + del +
-						funName + del +
 						getFunType(TYPEOF(call.callee));
 				} else {
 					callCount[currentKey] = ++callCount[currentKey];
@@ -149,7 +184,9 @@ namespace rir {
 							myfile
 								<< i++ // SNO
 								<< del
-								<< basicData[*ir] // ID, NAME, TYPE
+								<< names[*ir]->get_name() // NAME
+								<< del
+								<< basicData[*ir] // ID, TYPE
 								<< del
 								<< contextCallCount[*itr] // CONTEXT_CALL_COUNT
 								<< del
@@ -160,7 +197,9 @@ namespace rir {
 						myfile
 							<< i++ // SNO
 							<< del
-							<< basicData[*ir] // ID, NAME, TYPE
+							<< names[*ir]->get_name() // NAME
+							<< del
+							<< basicData[*ir] // ID, TYPE
 							<< del
 							<< callCount[*ir] // CALL_COUNT
 							<< del


### PR DESCRIPTION
Currently, when profiling this code
```
for (i in 1:10) {
    base::identity(1)
}
```

the profiler will not report that the function `base::identity` (or `identity`) is getting compiled.

Here `lhs` is `base::identity` of type `LANGSXP`, so the current code tries to read `R_NilValue->u.symsxp.pname` (through `CHAR`) which is not specified and can end up being anything (accessing this part o the union is only valid on SEXPs of type SYMSXP, not on NILSXP) !

This fixes the issue by dealing with left hand sides of the form `pkg::fun` and `pkg:::fun`.

This also (poorly) addresses the issue of anonymous functions:

```
F <- function() { identity }
for (i in 1:10) { F()(1) }
```

Here `identity` is called as an anonymous function (returned by the call `F()`). It might be possible to recover its name ; currently I simply log it as ``` `ANONYMOUS_FUNCTION_n` ``` where `n` is a number. The issue with the current implementation is that two compilation of the same anonymous functions will use different values of `n`. 

Note: handling anonymous functions would also handle the `::` and `:::` cases, as `base::identity` actually corresponds to the call ``` `::`(base, identity)``` which returns an anonymous function.