### PR TITLE
ContextualProfiler: also log function calls that go through rirApplyClosure

### DIFF
--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -3926,6 +3926,10 @@ SEXP rirApplyClosure(SEXP ast, SEXP op, SEXP arglist, SEXP rho,
     call.arglist = arglist;
     call.safeForceArgs();
 
+    ContextualProfiling::createCallEntry(
+      call
+    );
+
     auto res = rirCall(call, ctx);
     ostack_popn(ctx, call.passedArgs);
     return res;


### PR DESCRIPTION
Currently, the profiler only logs function calls that go through `doCall` (and then `rirCall`), but ignores the function calls that are processed through `rirApplyClosure`. This excludes a number of important function calls: in particular all the function calls processed in the `eval` function in `eval.c` in GnuR (even when they call rir bytecode) are ignored. Specifically, this excludes all toplevel function calls:

```
g <- function() { 3 }
f <- function() { g() }


f()
f()
f()
f()
f()
f()
```

There, `g` was logged in `profile/` but not `f`, even if it gets compiled to pir. Now we get 

```
Sno,name,id,type,callCount,callContexts,PIRCompiled
1,g,94204143775584,CLOSXP,5,< >,FALSE
2,f,94204143774688,CLOSXP,5,< >,FALSE
3,f,94204143774688,CLOSXP,1,< >,TRUE
```

Not sure if the count is correct, but at least it's in there :)