### PR TITLE
Refactor to avoid multi-key maps + count successful/failed compilation

### DIFF
--- a/rir/src/api.cpp
+++ b/rir/src/api.cpp
@@ -14,6 +14,8 @@
 #include "interpreter/interp_incl.h"
 #include "ir/BC.h"
 #include "ir/Compiler.h"
+#include "utils/ContextualProfiling.h"
+
 
 #include <cassert>
 #include <cstdio>
@@ -309,6 +311,8 @@ SEXP pirCompile(SEXP what, const Context& assumptions, const std::string& name,
 
                            auto fun = backend.getOrCompile(c);
 
+                            ContextualProfiling::countSuccessfulCompilation(what,assumptions);
+
                            // Install
                            if (dryRun)
                                return;
@@ -317,7 +321,8 @@ SEXP pirCompile(SEXP what, const Context& assumptions, const std::string& name,
                            DispatchTable::unpack(BODY(what))->insert(fun);
                        },
                        [&]() {
-                           if (debug.includes(pir::DebugFlag::ShowWarnings))
+                            ContextualProfiling::countFailedCompilation(what,assumptions);
+                            if (debug.includes(pir::DebugFlag::ShowWarnings))
                                std::cerr << "Compilation failed\n";
                        },
                        {});

--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -1076,11 +1076,6 @@ RIR_INLINE SEXP rirCall(CallContext& call, InterpreterInstance* ctx) {
         }
     }
 
-    ContextualProfiling::addRirCallData(
-        lMethodId,
-        lContext
-    );
-
     ContextualProfiling::addFunctionDispatchInfo(
         lMethodId,
         lContext,

--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -1058,7 +1058,6 @@ RIR_INLINE SEXP rirCall(CallContext& call, InterpreterInstance* ctx) {
     size_t lMethodId = ContextualProfiling::getEntryKey(call);
     std::string lMethodName = ContextualProfiling::getFunctionName(call);
     Context lContext = call.givenContext;
-    bool compilationTrigger = false;
     // For Logger -- END
 
     if (!isDeoptimizing() && RecompileHeuristic(table, fun)) {
@@ -1072,7 +1071,6 @@ RIR_INLINE SEXP rirCall(CallContext& call, InterpreterInstance* ctx) {
         fun->clearDisabledAssumptions(given);
         if (RecompileCondition(table, fun, given)) {
             if (given.includes(pir::Compiler::minimalContext)) {
-                compilationTrigger = true;
                 DoRecompile(fun, call.ast, call.callee, given, ctx);
                 fun = dispatch(call, table);
             }
@@ -1082,8 +1080,7 @@ RIR_INLINE SEXP rirCall(CallContext& call, InterpreterInstance* ctx) {
     ContextualProfiling::addRirCallData(
         lMethodId,
         lMethodName,
-        lContext,
-        compilationTrigger
+        lContext
     );
 
     ContextualProfiling::addFunctionDispatchInfo(

--- a/rir/src/interpreter/interp.cpp
+++ b/rir/src/interpreter/interp.cpp
@@ -1056,7 +1056,6 @@ RIR_INLINE SEXP rirCall(CallContext& call, InterpreterInstance* ctx) {
 
     // For Logger -- START
     size_t lMethodId = ContextualProfiling::getEntryKey(call);
-    std::string lMethodName = ContextualProfiling::getFunctionName(call);
     Context lContext = call.givenContext;
     // For Logger -- END
 
@@ -1079,7 +1078,6 @@ RIR_INLINE SEXP rirCall(CallContext& call, InterpreterInstance* ctx) {
 
     ContextualProfiling::addRirCallData(
         lMethodId,
-        lMethodName,
         lContext
     );
 

--- a/rir/src/utils/ContextualProfiling.cpp
+++ b/rir/src/utils/ContextualProfiling.cpp
@@ -189,10 +189,11 @@ namespace rir {
 					lContexts.emplace(id, set<Context>{{context,}});
 				}
 
-				if (lContextCallCount.find(getContextId(id, context)) != lContextCallCount.end()) {
-					lContextCallCount.at(getContextId(id, context))++;
+				auto contextId = getContextId(id, context);
+				if (lContextCallCount.find(contextId) != lContextCallCount.end()) {
+					lContextCallCount.at(contextId)++;
 				} else {
-					lContextCallCount.emplace(getContextId(id, context), 1);
+					lContextCallCount.emplace(contextId, 1);
 				}
 			}
 

--- a/rir/src/utils/ContextualProfiling.cpp
+++ b/rir/src/utils/ContextualProfiling.cpp
@@ -186,20 +186,16 @@ namespace rir {
 				lIds.insert(id);
 				lNames[id] = name;
 
-				if (lContexts.find(id) == lContexts.end()) {
-					set<Context> currContext;
-					currContext.insert(context);
-					lContexts[id] = currContext;
+				if (lContexts.find(id) != lContexts.end()) {
+					lContexts.at(id).insert(context);
 				} else {
-					set<Context> mod = lContexts[id];
-					mod.insert(context);
-					lContexts[id] = mod;
+					lContexts.emplace(id, set<Context>{{context}});
 				}
 
-				if (lContextCallCount.find(getContextId(id, context)) == lContextCallCount.end()) {
-					lContextCallCount[getContextId(id, context)] = 1;
+				if (lContextCallCount.find(getContextId(id, context)) != lContextCallCount.end()) {
+					lContextCallCount.at(getContextId(id, context))++;
 				} else {
-					lContextCallCount[getContextId(id, context)] = lContextCallCount[getContextId(id, context)] + 1;
+					lContextCallCount.emplace(getContextId(id, context), 1);
 				}
 			}
 
@@ -213,17 +209,17 @@ namespace rir {
 
 				auto funContextId = getContextId(id, funContext);
 
-				if (lDispatchedFunctions.find(contextId) == lDispatchedFunctions.end()) {
-					set<Context> currFunctions;
-					currFunctions.insert(funContext);
-					lDispatchedFunctions[contextId] = currFunctions;
 
-					lDispatchedFunctionsCount[funContextId] = 1;
+				if (! lDispatchedFunctions.count(contextId)) {
+					lDispatchedFunctions.emplace(contextId, set<Context>{{funContext,}});
 				} else {
-					set<Context> mod = lDispatchedFunctions[contextId];
-					mod.insert(funContext);
-					lDispatchedFunctions[contextId] = mod;
-					lDispatchedFunctionsCount[funContextId] = lDispatchedFunctionsCount[funContextId] + 1;
+					lDispatchedFunctions.at(contextId).insert(funContext);
+				}
+
+				if (! lDispatchedFunctionsCount.count(funContextId)) {
+					lDispatchedFunctionsCount.emplace(funContextId, 1);
+				} else {
+					lDispatchedFunctionsCount.at(funContextId)++;
 				}
 			}
 

--- a/rir/src/utils/ContextualProfiling.cpp
+++ b/rir/src/utils/ContextualProfiling.cpp
@@ -131,8 +131,11 @@ namespace rir {
 					case SPECIALSXP: return "SPECIALSXP";
 					case BUILTINSXP: return "BUILTINSXP";
 					case CLOSXP: return "CLOSXP";
-					default: return "TYPE_NO_" + type;
-				}
+					default:
+						stringstream ss;
+						ss << "TYPE_NO_" << type;
+						return ss.str();
+					}
 			}
 
 			void createEntry(CallContext& call) {

--- a/rir/src/utils/ContextualProfiling.h
+++ b/rir/src/utils/ContextualProfiling.h
@@ -27,13 +27,20 @@ class ContextualProfiling {
     static void addRirCallData(
       size_t,
       std::string,
-      Context,
-      bool
+      Context
     );
     static void addFunctionDispatchInfo(
       size_t,
       Context,
       Function
+    );
+    static void countSuccessfulCompilation(
+      SEXP,
+      Context const&
+    );
+    static void countFailedCompilation(
+      SEXP,
+      Context const&
     );
 };
 

--- a/rir/src/utils/ContextualProfiling.h
+++ b/rir/src/utils/ContextualProfiling.h
@@ -18,15 +18,11 @@ class ContextualProfiling {
     //   CallContext&,
     //   std::string
     // );
-    static std::string getFunctionName(
-      CallContext&
-    );
     static size_t getEntryKey(
       CallContext&
     );
     static void addRirCallData(
       size_t,
-      std::string,
       Context
     );
     static void addFunctionDispatchInfo(

--- a/rir/src/utils/ContextualProfiling.h
+++ b/rir/src/utils/ContextualProfiling.h
@@ -7,7 +7,7 @@ namespace rir {
 class ContextualProfiling {
   public:
     static void createCallEntry(
-      CallContext& // logs [ name, callType ]
+      CallContext const& // logs [ name, callType ]
       );
     static void recordCodePoint(
       int,
@@ -19,24 +19,20 @@ class ContextualProfiling {
     //   std::string
     // );
     static size_t getEntryKey(
-      CallContext&
-    );
-    static void addRirCallData(
-      size_t,
-      Context
+      CallContext const&
     );
     static void addFunctionDispatchInfo(
       size_t,
       Context,
-      Function
+      Function const&
     );
     static void countSuccessfulCompilation(
       SEXP,
-      Context const&
+      Context
     );
     static void countFailedCompilation(
       SEXP,
-      Context const&
+      Context
     );
 };
 


### PR DESCRIPTION
Count successful and failed compilation separately per context call. And some minor modifications:

- use the pair (fun_id, ctxt_id) as the key in the maps instead of the sum of these two values. It is too easy to get a collision using only the sum. This makes the file a bit ugly: the specialization of `hash` must in done in namespace `std`, so before the anonymous namespace.
-  fix the default case in `getFunctionName` (although I have never seen it used)